### PR TITLE
BUGFIX: use of "profile.tf" in example causes issue for Challenge-04

### DIFF
--- a/Challenges/Challenge-03.md
+++ b/Challenges/Challenge-03.md
@@ -18,7 +18,7 @@ Spaceship mission is too important to have crucial code being distributed here a
 
 Example:
 
-MyRepo/ElenaKim/profile.tf
+MyRepo/ElenaKim/profile.md
 
 ```hcl
 resource "spaceship_crew_member" "elena_kim" {


### PR DESCRIPTION
Challenge-03 provides sample code using the filename `profile.tf`.

This causes an issue for participants in Challenge-04, when they go to create their Terraform scripts, with an existing .tf file in their folder.  Participants encounter a Terraform error, when it tries to parse `profile.tf`.

Suggest rename to `profile.md` for consistency with Challenge-01 (even though it's not really a Markdown file...)